### PR TITLE
Fixes to elastic unit conversion

### DIFF
--- a/src/materialsframework/analysis/cubic_elastic_constants.py
+++ b/src/materialsframework/analysis/cubic_elastic_constants.py
@@ -15,6 +15,7 @@ from ase import Atoms
 from pymatgen.analysis.elasticity import ElasticTensor
 from pymatgen.analysis.eos import EOS
 from pymatgen.io.ase import AseAtomsAdaptor
+from ase import units
 
 from materialsframework.transformations.cubic_elastic_constants import (
     CubicElasticConstantsDeformationTransformation,
@@ -126,12 +127,12 @@ class CubicElasticConstantsAnalyzer:
             "C12": c12,
             "C44": c44,
             "youngs_modulus": elastic_tensor.y_mod / 1e9,
-            "voigt_bulk_modulus": elastic_tensor.k_voigt,
-            "voigt_shear_modulus": elastic_tensor.g_voigt,
-            "reuss_bulk_modulus": elastic_tensor.k_reuss,
-            "reuss_shear_modulus": elastic_tensor.g_reuss,
-            "voigt_reuss_hill_bulk_modulus": elastic_tensor.k_vrh,
-            "voigt_reuss_hill_shear_modulus": elastic_tensor.g_vrh,
+            "voigt_bulk_modulus": elastic_tensor.k_voigt / units.GPa,
+            "voigt_shear_modulus": elastic_tensor.g_voigt / units.GPa,
+            "reuss_bulk_modulus": elastic_tensor.k_reuss / units.GPa,
+            "reuss_shear_modulus": elastic_tensor.g_reuss / units.GPa,
+            "voigt_reuss_hill_bulk_modulus": elastic_tensor.k_vrh / units.GPa,
+            "voigt_reuss_hill_shear_modulus": elastic_tensor.g_vrh / units.GPa,
             "poisson_ratio": elastic_tensor.homogeneous_poisson,
             "pugh_ratio": elastic_tensor.g_vrh / elastic_tensor.k_vrh,
         }

--- a/src/materialsframework/analysis/elastic_constants.py
+++ b/src/materialsframework/analysis/elastic_constants.py
@@ -137,7 +137,8 @@ class ElasticConstantsAnalyzer:
 
         return {
             **dict(zip(cij_order, cij, strict=False)),
-            "youngs_modulus": elastic_tensor.y_mod / 1e9,
+            "youngs_modulus": elastic_tensor.y_mod / 1e9 / units.GPa, #TODO: pymatgen reports Young's modulus in Pa in its comments, but acutally returns 1e9*y_mod in eV/Å³,
+                                                                      # change when fixed https://github.com/materialsproject/pymatgen/issues/4435
             "voigt_bulk_modulus": elastic_tensor.k_voigt / units.GPa,
             "voigt_shear_modulus": elastic_tensor.g_voigt / units.GPa,
             "reuss_bulk_modulus": elastic_tensor.k_reuss / units.GPa,
@@ -198,7 +199,7 @@ class ElasticConstantsAnalyzer:
             elastic_tensor[i, j] = elastic_tensor[j, i] = val
 
         for block in self.EQUIV.get(sys := elastic.get_lattice_type(structure)[1].lower(), []):
-            mean_val = np.mean([elastic_tensor[p, q] for p, q in block])
+            mean_val = np.max([elastic_tensor[p, q] for p, q in block])
             for p, q in block:
                 elastic_tensor[p, q] = elastic_tensor[q, p] = mean_val
 

--- a/src/materialsframework/analysis/elastic_constants.py
+++ b/src/materialsframework/analysis/elastic_constants.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from pymatgen.analysis.elasticity import ElasticTensor
 from pymatgen.core import Structure
+from ase import units
 
 from materialsframework.tools import elastic
 from materialsframework.transformations.elastic_constants import (
@@ -137,12 +138,12 @@ class ElasticConstantsAnalyzer:
         return {
             **dict(zip(cij_order, cij, strict=False)),
             "youngs_modulus": elastic_tensor.y_mod / 1e9,
-            "voigt_bulk_modulus": elastic_tensor.k_voigt,
-            "voigt_shear_modulus": elastic_tensor.g_voigt,
-            "reuss_bulk_modulus": elastic_tensor.k_reuss,
-            "reuss_shear_modulus": elastic_tensor.g_reuss,
-            "voigt_reuss_hill_bulk_modulus": elastic_tensor.k_vrh,
-            "voigt_reuss_hill_shear_modulus": elastic_tensor.g_vrh,
+            "voigt_bulk_modulus": elastic_tensor.k_voigt / units.GPa,
+            "voigt_shear_modulus": elastic_tensor.g_voigt / units.GPa,
+            "reuss_bulk_modulus": elastic_tensor.k_reuss / units.GPa,
+            "reuss_shear_modulus": elastic_tensor.g_reuss / units.GPa,
+            "voigt_reuss_hill_bulk_modulus": elastic_tensor.k_vrh / units.GPa,
+            "voigt_reuss_hill_shear_modulus": elastic_tensor.g_vrh / units.GPa,
             "poisson_ratio": elastic_tensor.homogeneous_poisson,
             "pugh_ratio": elastic_tensor.g_vrh / elastic_tensor.k_vrh,
         }

--- a/src/materialsframework/analysis/elastic_constants.py
+++ b/src/materialsframework/analysis/elastic_constants.py
@@ -199,9 +199,9 @@ class ElasticConstantsAnalyzer:
             elastic_tensor[i, j] = elastic_tensor[j, i] = val
 
         for block in self.EQUIV.get(sys := elastic.get_lattice_type(structure)[1].lower(), []):
-            mean_val = np.max([elastic_tensor[p, q] for p, q in block])
+            non_zero_val = np.max([elastic_tensor[p, q] for p, q in block])
             for p, q in block:
-                elastic_tensor[p, q] = elastic_tensor[q, p] = mean_val
+                elastic_tensor[p, q] = elastic_tensor[q, p] = non_zero_val
 
         # add the derived C66 if required
         if sys in self.SPECIAL and elastic_tensor[5, 5] == 0:


### PR DESCRIPTION
The elastic analyzers report that they output in units of GPa but it seems like they are actually outputting in the ase/pymatgen units of eV/A^3. This should be verifiable by looking at the tools/elastic.py get_elastic_tensor function and the analyzers' calculate and _build_elastic_tensor methods. Fixed by using ase.units conversion to GPa